### PR TITLE
Revert latest gamedata changes for non-TF2.

### DIFF
--- a/connect.games.txt
+++ b/connect.games.txt
@@ -4,8 +4,10 @@
 	{
 		"#supported"
 		{
-			"engine"    "orangebox_valve"
+			"engine"    "dods"
 			"engine"    "css"
+			"engine"    "hl2dm"
+			"engine"    "tf2"
 		}
 
 		"Offsets"
@@ -43,6 +45,54 @@
 				"windows"       "\x55\x8B\xEC\x83\xEC\x14\x53\x8B\x5D\x14"
 			}
 
+			"CBaseServer__CheckMasterServerRequestRestart"
+			{
+				"library"       "engine"
+				"windows"       "\xE8\x2A\x2A\x2A\x2A\x83\x78\x04\x00\x74\x2A\xE8\x2A\x2A\x2A\x2A\x8B\x48\x04\x8B\x01\x8B\x40\x2C\xFF\xD0\x84\xC0\x74\x2A\x56"
+			}
+
+			"Steam3Server"
+			{
+				"library"       "engine"
+				"linux"         "@_Z12Steam3Serverv"
+				"mac"           "@_Z12Steam3Serverv"
+			}
+		}
+	}
+	
+	"#default"
+	{
+		"#supported"
+		{
+			"engine"    "dods"
+			"engine"    "css"
+			"engine"    "hl2dm"
+		}
+		
+		"Signatures"
+		{
+			"CBaseServer__RejectConnection"
+			{
+				"library"       "engine"
+				"linux"         "@_ZN11CBaseServer16RejectConnectionERK8netadr_siPKc"
+				"mac"           "@_ZN11CBaseServer16RejectConnectionERK8netadr_siPKc"
+				"windows"       "\x55\x8B\xEC\x81\xEC\x04\x05\x00\x00\x56\x6A\xFF"
+			}
+
+			"CBaseClient__SetSteamID"
+			{
+				"library"       "engine"
+				"linux"         "@_ZN11CBaseClient10SetSteamIDERK8CSteamID"
+				"mac"           "@_ZN11CBaseClient10SetSteamIDERK8CSteamID"
+				"windows"       "\x55\x8B\xEC\x8B\x55\x08\x8B\x02\x89\x41\x59\x8B\x42\x04"
+			}
+		}
+	}
+	
+	"tf2"
+	{
+		"Signatures"
+		{
 			"CBaseServer__RejectConnection"
 			{
 				"library"       "engine"
@@ -57,19 +107,6 @@
 				"linux"         "@_ZN11CBaseClient10SetSteamIDERK8CSteamID"
 				"mac"           "@_ZN11CBaseClient10SetSteamIDERK8CSteamID"
 				"windows"       "\x55\x8B\xEC\x56\x57\x8B\x7D\x08\x8B\xF1\x8D\x4E\x04"
-			}
-
-			"CBaseServer__CheckMasterServerRequestRestart"
-			{
-				"library"       "engine"
-				"windows"       "\xE8\x2A\x2A\x2A\x2A\x83\x78\x04\x00\x74\x2A\xE8\x2A\x2A\x2A\x2A\x8B\x48\x04\x8B\x01\x8B\x40\x2C\xFF\xD0\x84\xC0\x74\x2A\x56"
-			}
-
-			"Steam3Server"
-			{
-				"library"       "engine"
-				"linux"         "@_Z12Steam3Serverv"
-				"mac"           "@_Z12Steam3Serverv"
 			}
 		}
 	}


### PR DESCRIPTION
The other supported games haven't had an update yet and require the previous signatures.