### PR TITLE
Fix extension rejecting valid auth tickets

### DIFF
--- a/connect.games.txt
+++ b/connect.games.txt
@@ -106,6 +106,22 @@
 
 		"Offsets"
 		{
+			"ISteamGameServer__BeginAuthSession"
+			{
+				"linux"         "26"
+				"linux64"       "26"
+				"windows"       "26"
+				"windows64"     "26"
+			}
+
+			"ISteamGameServer__EndAuthSession"
+			{
+				"linux"         "27"
+				"linux64"       "27"
+				"windows"       "27"
+				"windows64"     "27"
+			}
+
 			"CheckMasterServerRequestRestart_Steam3ServerFuncOffset"
 			{
 				"windows"		"240"

--- a/connect.games.txt
+++ b/connect.games.txt
@@ -81,14 +81,6 @@
 				"windows"       "\x55\x8B\xEC\x8B\x55\x08\x8B\x02\x89\x41\x59\x8B\x42\x04"
 			}
 
-			"CBaseServer__CheckChallengeType"
-			{
-				"library"       "engine"
-				"linux"         "@_ZN11CBaseServer18CheckChallengeTypeEP11CBaseClientiR8netadr_siPKcii"
-				"mac"           "@_ZN11CBaseServer18CheckChallengeTypeEP11CBaseClientiR8netadr_siPKcii"
-				"windows"       "\x55\x8B\xEC\x83\xEC\x14\x56\x57\x8B\x7D\x2A\x8B\xF1"
-			}
-
 			"CBaseServer__CheckMasterServerRequestRestart"
 			{
 				"library"       "engine"
@@ -152,14 +144,6 @@
 				"linux"         "@_ZN11CBaseClient10SetSteamIDERK8CSteamID"
 				"linux64"       "@_ZN11CBaseClient10SetSteamIDERK8CSteamID"
 				"windows"       "\x55\x8B\xEC\x56\x8B\xF1\x57\x8B\x7D\x08\x8D\x4E\x04"
-			}
-
-			"CBaseServer__CheckChallengeType"
-			{
-				"library"       "engine"
-				"linux"         "@_ZN11CBaseServer18CheckChallengeTypeEP11CBaseClientiR8netadr_siPKcii"
-				"linux64"       "@_ZN11CBaseServer18CheckChallengeTypeEP11CBaseClientiR8netadr_siPKcii"
-				"windows"       "\x55\x8B\xEC\x83\xEC\x14\x53\x8B\x5D\x14"
 			}
 
 			"CBaseServer__CheckMasterServerRequestRestart"

--- a/extension/extension.cpp
+++ b/extension/extension.cpp
@@ -188,7 +188,7 @@ EBeginAuthSessionResult Hook_BeginAuthSession(const void *pAuthTicket, int cbAut
 
 	// Regular auth session ?
 	auto result = META_RESULT_ORIG_RET(EBeginAuthSessionResult);
-	if (META_RESULT_ORIG_RET(EBeginAuthSessionResult) == k_EBeginAuthSessionResultDuplicateRequest)
+	if (result == k_EBeginAuthSessionResultDuplicateRequest)
 	{
 		if (strcmp(steamID.Render(), g_lastAuthSteamID.c_str()) == 0 && g_lastAuthTicket == pAuthTicket && g_lastcbAuthTicket == cbAuthTicket && g_lastAuthSessionResult == k_EBeginAuthSessionResultOK)
 		{

--- a/extension/extension.h
+++ b/extension/extension.h
@@ -100,4 +100,24 @@ public: //IConCommandBaseAccessor
 	bool RegisterConCommandBase(ConCommandBase *pCommand);
 };
 
+#define DETOUR_DECL_MEMBER9(name, ret, p1type, p1name, p2type, p2name, p3type, p3name, p4type, p4name, p5type, p5name, p6type, p6name, p7type, p7name, p8type, p8name, p9type, p9name) \
+class name##Class \
+{ \
+public: \
+        ret name(p1type p1name, p2type p2name, p3type p3name, p4type p4name, p5type p5name, p6type p6name, p7type p7name, p8type p8name, p9type p9name); \
+        static ret (name##Class::* name##_Actual)(p1type, p2type, p3type, p4type, p5type, p6type, p7type, p8type, p9type); \
+}; \
+ret (name##Class::* name##Class::name##_Actual)(p1type, p2type, p3type, p4type, p5type, p6type, p7type, p8type, p9type) = NULL; \
+ret name##Class::name(p1type p1name, p2type p2name, p3type p3name, p4type p4name, p5type p5name, p6type p6name, p7type p7name, p8type p8name, p9type p9name)
+
+struct mfpDetails {
+	void *addr;
+	intptr_t adjustor;
+
+	void Init(void* addr, intptr_t adj = 0) {
+		this->addr = addr;
+		this->adjustor = adj;
+	}
+};
+
 #endif // _INCLUDE_SOURCEMOD_EXTENSION_PROPER_H_


### PR DESCRIPTION
- Fixes #19
- Fixes an unreported bug, where older version of the extension would reject steam tickets due to old gamedata
- Fixes the extension causing the srcds to reject valid auth tickets, due to begining the auth session too early