### PR TITLE
Support windows64 and unify gamedata after source-sdk-2013 (2025) update

### DIFF
--- a/connect.games.txt
+++ b/connect.games.txt
@@ -45,54 +45,6 @@
 			"engine"    "dods"
 			"engine"    "css"
 			"engine"    "hl2dm"
-		}
-
-		"Offsets"
-		{
-			"CheckMasterServerRequestRestart_Steam3ServerFuncOffset"
-			{
-				"windows"		"1"
-			}
-		}
-
-		"Signatures"
-		{
-			"CBaseServer__ConnectClient"
-			{
-				"library"       "engine"
-				"linux"         "@_ZN11CBaseServer13ConnectClientER8netadr_siiiiPKcS3_S3_i"
-				"mac"           "@_ZN11CBaseServer13ConnectClientER8netadr_siiiiPKcS3_S3_i"
-				"windows"       "\x55\x8B\xEC\x81\xEC\x04\x05\x00\x00\x56\x68\x2A\x2A\x2A\x2A\x8B\xF1"
-			}
-
-			"CBaseServer__RejectConnection"
-			{
-				"library"       "engine"
-				"linux"         "@_ZN11CBaseServer16RejectConnectionERK8netadr_siPKc"
-				"mac"           "@_ZN11CBaseServer16RejectConnectionERK8netadr_siPKc"
-				"windows"       "\x55\x8B\xEC\x81\xEC\x04\x05\x00\x00\x56\x6A\xFF"
-			}
-
-			"CBaseClient__SetSteamID"
-			{
-				"library"       "engine"
-				"linux"         "@_ZN11CBaseClient10SetSteamIDERK8CSteamID"
-				"mac"           "@_ZN11CBaseClient10SetSteamIDERK8CSteamID"
-				"windows"       "\x55\x8B\xEC\x8B\x55\x08\x8B\x02\x89\x41\x59\x8B\x42\x04"
-			}
-
-			"CBaseServer__CheckMasterServerRequestRestart"
-			{
-				"library"       "engine"
-				"windows"       "\xE8\x2A\x2A\x2A\x2A\x83\x78\x04\x00\x74\x2A\xE8\x2A\x2A\x2A\x2A\x8B\x48\x04\x8B\x01\x8B\x40\x2C\xFF\xD0\x84\xC0\x74\x2A\x56"
-			}
-		}
-	}
-
-	"#default"
-	{
-		"#supported"
-		{
 			"engine"    "tf2"
 		}
 
@@ -117,6 +69,7 @@
 			"CheckMasterServerRequestRestart_Steam3ServerFuncOffset"
 			{
 				"windows"		"240"
+				"windows64"     "299"
 			}
 		}
 
@@ -128,6 +81,7 @@
 				"linux"         "@_ZN11CBaseServer13ConnectClientER8netadr_siiiiPKcS3_S3_i"
 				"linux64"       "@_ZN11CBaseServer13ConnectClientER8netadr_siiiiPKcS3_S3_i"
 				"windows"       "\x55\x8B\xEC\x81\xEC\x24\x05\x00\x00\x53\x56\x57\x68\x2A\x2A\x2A\x2A"
+				"windows64"     "\x48\x89\x5C\x24\x2A\x44\x89\x4C\x24\x2A\x55\x56\x57\x41\x54\x41\x55\x41\x56\x41\x57\x48\x81\xEC\x80\x05\x00\x00"
 			}
 
 			"CBaseServer__RejectConnection"
@@ -136,6 +90,7 @@
 				"linux"         "@_ZN11CBaseServer16RejectConnectionERK8netadr_siPKc"
 				"linux64"       "@_ZN11CBaseServer16RejectConnectionERK8netadr_siPKc"
 				"windows"       "\x55\x8B\xEC\x81\xEC\x04\x05\x00\x00\x57"
+				"windows64"     "\x48\x89\x5C\x24\x2A\x48\x89\x6C\x24\x2A\x48\x89\x74\x24\x2A\x57\x48\x81\xEC\x50\x05\x00\x00"
 			}
 
 			"CBaseClient__SetSteamID"
@@ -144,12 +99,14 @@
 				"linux"         "@_ZN11CBaseClient10SetSteamIDERK8CSteamID"
 				"linux64"       "@_ZN11CBaseClient10SetSteamIDERK8CSteamID"
 				"windows"       "\x55\x8B\xEC\x56\x8B\xF1\x57\x8B\x7D\x08\x8D\x4E\x04"
+				"windows64"     "\x48\x89\x5C\x24\x2A\x57\x48\x83\xEC\x20\x48\x8B\x02\x48\x8B\xD9\x48\x89\x41"
 			}
 
 			"CBaseServer__CheckMasterServerRequestRestart"
 			{
 				"library"       "engine"
 				"windows"       "\x55\x8B\xEC\x83\xEC\x1C\x53\x57\x33\xD2"
+				"windows64"     "\x4C\x8B\xDC\x49\x89\x5B\x2A\x49\x89\x6B\x2A\x56\x57\x41\x54\x41\x56\x41\x57\x48\x83\xEC\x60\x48\x8B\x05\x2A\x2A\x2A\x2A\x48\x8D\x1D"
 			}
 		}
 	}

--- a/extension/extension.cpp
+++ b/extension/extension.cpp
@@ -99,13 +99,13 @@ CBaseServer *g_pBaseServer = NULL;
 
 typedef CSteam3Server *(*Steam3ServerFunc)();
 
-#ifndef WIN32
+#if !defined(WIN32) || defined(WIN64)
 typedef void (*RejectConnectionFunc)(CBaseServer *, const netadr_t &address, int iClientChallenge, const char *pchReason);
 #else
 typedef void (__fastcall *RejectConnectionFunc)(CBaseServer *, void *, const netadr_t &address, int iClientChallenge, const char *pchReason);
 #endif
 
-#ifndef WIN32
+#if !defined(WIN32) || defined(WIN64)
 typedef void (*SetSteamIDFunc)(CBaseClient *, const CSteamID &steamID);
 #else
 typedef void (__fastcall *SetSteamIDFunc)(CBaseClient *, void *, const CSteamID &steamID);
@@ -139,7 +139,7 @@ void RejectConnection(const netadr_t &address, int iClientChallenge, const char 
 	if (!g_pRejectConnectionFunc || !g_pBaseServer)
 		return;
 
-#ifndef WIN32
+#if !defined(WIN32) || defined(WIN64)
 	g_pRejectConnectionFunc(g_pBaseServer, address, iClientChallenge, pchReason);
 #else
 	g_pRejectConnectionFunc(g_pBaseServer, NULL, address, iClientChallenge, pchReason);
@@ -151,7 +151,7 @@ void SetSteamID(CBaseClient *pClient, const CSteamID &steamID)
 	if (!pClient || !g_pSetSteamIDFunc)
 		return;
 
-#ifndef WIN32
+#if !defined(WIN32) || defined(WIN64)
 	g_pSetSteamIDFunc(pClient, steamID);
 #else
 	g_pSetSteamIDFunc(pClient, NULL, steamID);
@@ -338,9 +338,9 @@ bool Connect::SDK_OnLoad(char *error, size_t maxlen, bool late)
 
 	//META_CONPRINTF("CheckMasterServerRequestRestart: %p\n", address);
 	address = (void *)((intptr_t)address + steam3ServerFuncOffset);
-	intptr_t offset = (intptr_t)(*(void **)address); // Get offset
+	int32_t offset = (*(int32_t *)address); // Get offset (yes, int32 even on 64-bit)
 
-	g_pSteam3ServerFunc = (Steam3ServerFunc)((intptr_t)address + offset + sizeof(intptr_t));
+	g_pSteam3ServerFunc = (Steam3ServerFunc)((intptr_t)address + offset + sizeof(int32_t));
 	//META_CONPRINTF("Steam3Server: %p\n", g_pSteam3ServerFunc);
 #endif
 


### PR DESCRIPTION
All of the gamedata should:tm: now be the same, probably, with the SDK update. ***(Need help testing for everything other than CS:S though...)***

Also fixed windows64 by adding signatures, fixing the g_pSteam3ServerFunc offset stuff, and editing some calling convention stuff (that's only for windows32 to call thiscall via fastcall)