### PR TITLE
fix: reject connection crash

### DIFF
--- a/connect.games.txt
+++ b/connect.games.txt
@@ -108,6 +108,18 @@
 				"windows"       "\x55\x8B\xEC\x83\xEC\x1C\x53\x57\x33\xD2"
 				"windows64"     "\x4C\x8B\xDC\x49\x89\x5B\x2A\x49\x89\x6B\x2A\x56\x57\x41\x54\x41\x56\x41\x57\x48\x83\xEC\x60\x48\x8B\x05\x2A\x2A\x2A\x2A\x48\x8D\x1D"
 			}
+
+			"NET_SendPacket"
+			{
+				"library"		"engine"
+				"linux"			"@_Z14NET_SendPacketP11INetChanneliRK8netadr_sPKhiP8bf_writeb"
+			}
+
+			"NET_CheckCleanupFakeIPConnection"
+			{
+				"library"		"engine"
+				"linux"			"@_Z32NET_CheckCleanupFakeIPConnectioniRK8netadr_s"
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/asherkin/connect/issues/32

I dont know why it crashes instantly when we try to call the original function only inside the detoured function (does not crash if we dont try to detour but just call the function)

so i have just RE this function and re-implemented it here