### PR TITLE
Remove RejectConnection detour + unused signature

### DIFF
--- a/connect.games.txt
+++ b/connect.games.txt
@@ -84,24 +84,6 @@
 				"windows64"     "\x48\x89\x5C\x24\x2A\x44\x89\x4C\x24\x2A\x55\x56\x57\x41\x54\x41\x55\x41\x56\x41\x57\x48\x81\xEC\x80\x05\x00\x00"
 			}
 
-			"CBaseServer__RejectConnection"
-			{
-				"library"       "engine"
-				"linux"         "@_ZN11CBaseServer16RejectConnectionERK8netadr_siPKc"
-				"linux64"       "@_ZN11CBaseServer16RejectConnectionERK8netadr_siPKc"
-				"windows"       "\x55\x8B\xEC\x81\xEC\x04\x05\x00\x00\x57"
-				"windows64"     "\x48\x89\x5C\x24\x2A\x48\x89\x6C\x24\x2A\x48\x89\x74\x24\x2A\x57\x48\x81\xEC\x50\x05\x00\x00"
-			}
-
-			"CBaseClient__SetSteamID"
-			{
-				"library"       "engine"
-				"linux"         "@_ZN11CBaseClient10SetSteamIDERK8CSteamID"
-				"linux64"       "@_ZN11CBaseClient10SetSteamIDERK8CSteamID"
-				"windows"       "\x55\x8B\xEC\x56\x8B\xF1\x57\x8B\x7D\x08\x8D\x4E\x04"
-				"windows64"     "\x48\x89\x5C\x24\x2A\x57\x48\x83\xEC\x20\x48\x8B\x02\x48\x8B\xD9\x48\x89\x41"
-			}
-
 			"CBaseServer__CheckMasterServerRequestRestart"
 			{
 				"library"       "engine"

--- a/connect.games.txt
+++ b/connect.games.txt
@@ -84,6 +84,15 @@
 				"windows64"     "\x48\x89\x5C\x24\x2A\x44\x89\x4C\x24\x2A\x55\x56\x57\x41\x54\x41\x55\x41\x56\x41\x57\x48\x81\xEC\x80\x05\x00\x00"
 			}
 
+			"CBaseServer__RejectConnection"
+			{
+				"library"       "engine"
+				"linux"         "@_ZN11CBaseServer16RejectConnectionERK8netadr_siPKc"
+				"linux64"       "@_ZN11CBaseServer16RejectConnectionERK8netadr_siPKc"
+				"windows"       "\x55\x8B\xEC\x81\xEC\x04\x05\x00\x00\x57"
+				"windows64"     "\x48\x89\x5C\x24\x2A\x48\x89\x6C\x24\x2A\x48\x89\x74\x24\x2A\x57\x48\x81\xEC\x50\x05\x00\x00"
+			}
+
 			"CBaseServer__CheckMasterServerRequestRestart"
 			{
 				"library"       "engine"

--- a/extension/extension.cpp
+++ b/extension/extension.cpp
@@ -157,7 +157,6 @@ public:
 };
 
 CDetour* detourCBaseServer__ConnectClient = nullptr;
-bool g_bEndAuthSessionOnRejectConnection = false;
 bool g_bSuppressBeginAuthSession = false;
 CSteamID g_lastClientSteamID;
 const void* g_lastAuthTicket;

--- a/extension/extension.cpp
+++ b/extension/extension.cpp
@@ -308,9 +308,7 @@ bool Connect::SDK_OnLoad(char *error, size_t maxlen, bool late)
 
 	//META_CONPRINTF("CheckMasterServerRequestRestart: %p\n", address);
 	address = (void *)((intptr_t)address + steam3ServerFuncOffset);
-	int32_t offset = (*(int32_t *)address); // Get offset (yes, int32 even on 64-bit)
-
-	g_pSteam3ServerFunc = (Steam3ServerFunc)((intptr_t)address + offset + sizeof(int32_t));
+	g_pSteam3ServerFunc = (Steam3ServerFunc)((intptr_t)address + *((int32_t *)address) + sizeof(int32_t));
 	//META_CONPRINTF("Steam3Server: %p\n", g_pSteam3ServerFunc);
 #endif
 


### PR DESCRIPTION
- Removed `RejectConnection` detour, this should fix #27 
- Call `RejectConnection` with the correct calling convention, this should fix #32
- Removed `CBaseClient__SetSteamID` this signature is completely unused