### PR TITLE
Use Ubuntu 22.04 runners & clang 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2022]
+        os: [ubuntu-22.04, windows-2022]
         include:
-          - os: ubuntu-20.04
-            cc: clang-10
-            cxx: clang++-10
+          - os: ubuntu-22.04
+            cc: clang-11
+            cxx: clang++-11
           - os: windows-2022
             cc: msvc
       fail-fast: false


### PR DESCRIPTION
Github removed the Ubuntu 20.04 runners so this is a small bump to 22.04 (& clang 11) keep github actions working.

The minimum required glibc version (2.29?) seems to be the same too which is good (according to `objdump -T connect.ext.2.css.so | grep GLIBC | sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' | sort -Vu`).


<details><summary>ub20</summary>
2.0
2.1
2.1.3
2.2
2.2.4
2.7
2.29
</details>
<details><summary>ub22</summary>
2.0
2.1
2.1.3
2.2
2.2.4
2.7
2.29
2.32
2.34
</details>