### PR TITLE
Add apt update before installing python3-pip

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -8,6 +8,7 @@ if [[ $PLATFORM == Linux* ]]; then
 	$CC --version
 	$CXX --version
 
+	apt update
 	apt install -y python3-pip
 
 	# buildbot/generate_header.py is ran by ambuild and we want git to not fail due to user-perms (because docker)


### PR DESCRIPTION
Our workflow currently fails installing `python3-pip` with multiple 404 errors e.g : `404  Not Found [IP: 151.101.162.132 80]`

I think this is just a trivial issue with apt listing not being updated, so update it before installing any packages.